### PR TITLE
Engadir script de Piwik

### DIFF
--- a/index.html
+++ b/index.html
@@ -784,6 +784,27 @@
       map.addLayer(layer);
       })
     </script>
+			
+<!-- Piwik -->
+<script type="text/javascript">
+  var _paq = _paq || [];
+  _paq.push(["setDomains", ["*.hackatinho.gpul.org","*.hackathino.gpul.org","*.www.hackathino.gpul.org","*.www.hackatinho.gpul.org"]]);
+  _paq.push(["setDoNotTrack", true]);
+  _paq.push(["disableCookies"]);
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u="//analytics2.gpul.org/";
+    _paq.push(['setTrackerUrl', u+'piwik.php']);
+    _paq.push(['setSiteId', '2']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>
+<noscript><p><img src="//analytics2.gpul.org/piwik.php?idsite=2" style="border:0;" alt="" /></p></noscript>
+<!-- End Piwik Code -->
+
+
 
 	</body>
 </html>


### PR DESCRIPTION
Engádese unha opción para poder sacar analíticas do tráfico á web (sen cookies).

Non emprega cookies (co cal non temos o número de usuarios únicos real, pero tampouco nos debería de interesar tanto, xa que en xeral é unha páxina informativa e non interactiva).
